### PR TITLE
Add JIRA local environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,34 @@
 For testing, use `go test ./...` in the root directory
 For formatting, use your editor of choice, or run `gofmt -w .`, in the root directory.
 For running you can use `go run main/clira.go`, but ensure you get a working config file.
+
+## Development setup
+
+You'll need [minikube](https://kubernetes.io/docs/setup/minikube/), and a [MyAtlassian account](https://id.atlassian.com/login), with either a valid license or the ability to get a new evaluation license for 90 days.
+
+Clone the repo:
+```bash
+git clone https://github.com/ifosch/clira
+cd clira
+```
+
+Ensure your minikube has, at least 3 cpus and >2048 Mb of memory:
+```bash
+minikube stop
+minikube config set memory 4096
+minikube config set cpus 3
+minikube delete
+minikube start
+```
+
+Once minikube has enough resources:
+```bash
+kubectl apply -f manifests/loca-jira.yaml
+```
+
+Wait until the pod is finally running, and then you'll get your JIRA to be setup:
+```bash
+minikube service jira
+```
+
+Go ahead with standard JIRA setup (will require you to provide a license from Atlassian).

--- a/manifests/local-jira.yaml
+++ b/manifests/local-jira.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: jira-home
+  labels:
+    app: jira
+spec:
+  storageClassName: manual
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 50Gi
+  hostPath:
+    path: /var/lib/minikube/jira-home
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jira-home
+  labels:
+    app: jira
+spec:
+  storageClassName: manual
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: jira
+  name: jira
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jira
+  template:
+    metadata:
+      labels:
+        app: jira
+      name: jira
+    spec:
+      containers:
+        - name: jira
+          image: "gcr.io/hightowerlabs/jira:7.3.6-standalone"
+          resources:
+            requests:
+              cpu: "2"
+              memory: "2G"
+          volumeMounts:
+            - name: "jira-home"
+              mountPath: /opt/jira-home
+      volumes:
+        - name: "jira-home"
+          persistentVolumeClaim:
+            claimName: jira-home
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: jira
+  name: jira
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: jira
+  type: NodePort


### PR DESCRIPTION
With these instructions and the provided manifests, a JIRA local environment can be setup on top of minikube.