### PR TITLE
Add create sprint command

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ifosch/clira/pkg"
+)
+
+type newSprint struct {
+	Name          string `json:"name"`
+	OriginBoardID int    `json:"originBoardId"`
+}
+
+// createCmd represents the create command
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new sprint",
+	Long: `
+This subcommand allows sprint creation.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		jiraClient, err := clira.GetClient()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		board, err := clira.GetBoard(jiraClient)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		createdSprint := &newSprint{
+			Name:          args[0],
+			OriginBoardID: board.ID,
+		}
+		req, err := jiraClient.NewRequest(
+			"POST",
+			"rest/agile/1.0/sprint",
+			createdSprint,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		result := new(newSprint)
+		_, err = jiraClient.Do(req, result)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("New sprint created: ", result.Name)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(createCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// getCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// getCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}

--- a/pkg/clira.go
+++ b/pkg/clira.go
@@ -37,3 +37,35 @@ func GetTransition(
 	}
 	return
 }
+
+type boardResults struct {
+	MaxResults int          `json:"maxResults"`
+	StartAt    int          `json:"startAt"`
+	IsLast     bool         `json:"isLast"`
+	Values     []jira.Board `json:"values"`
+}
+
+// GetBoard returns the board for a user. If there is more than a board for a user, it returns an error. If the user can't see any board, it returns an error.
+func GetBoard(client *jira.Client) (board *jira.Board, err error) {
+	req, err := client.NewRequest(
+		"GET",
+		"rest/agile/1.0/board",
+		nil,
+	)
+	if err != nil {
+		return
+	}
+	result := new(boardResults)
+	_, err = client.Do(req, result)
+	if err != nil {
+		return
+	}
+	if len(result.Values) < 1 {
+		return nil, fmt.Errorf("Too few boards")
+	}
+	if len(result.Values) > 1 {
+		return nil, fmt.Errorf("Too many boards")
+	}
+	board = &result.Values[0]
+	return
+}


### PR DESCRIPTION
The create command creates a sprint with the specified name in the only user's visible board.

It works like:

``` bash
clira create <sprint_name>
```